### PR TITLE
Updated docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.10-slim
 
 ENV APP_DIR=/virtual_library_card/ \
-    DJANGO_SETTINGS_MODULE=virtual_library_card.settings.prod
+    DJANGO_SETTINGS_MODULE=virtual_library_card.settings.prod \
+    POETRY_VIRTUALENVS_CREATE=false
 
 ENV UWSGI_MASTER=1 \
     UWSGI_HTTP_AUTO_CHUNKED=1 \
@@ -22,6 +23,7 @@ ENV UWSGI_MASTER=1 \
     UWSGI_LOGFORMAT="[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(clean_uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))"
 
 ARG POETRY_VERSION=1.7.1
+ARG REPO=ThePalaceProject/virtual-library-card
 
 # Install system
 RUN apt-get update -y && \
@@ -29,22 +31,30 @@ RUN apt-get update -y && \
     curl mime-support && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version "$POETRY_VERSION" && \
     ln -s /opt/poetry/bin/poetry /bin/poetry && \
-    apt-get remove curl -y && \
     apt-get autoremove -y && \
     rm -Rf /var/lib/apt/lists/* && \
     rm -Rf /root/.cache && \
     find /opt /usr -type d -name "__pycache__" -exec rm -rf {} +
 
-# Install Python dependencies
-COPY pyproject.toml poetry.lock $APP_DIR
 WORKDIR $APP_DIR
-RUN POETRY_VIRTUALENVS_CREATE=false poetry install --only main --no-interaction && \
+
+# Do basic python dependency install
+# We use curl here to grab our poetry.lock and pyproject.toml files from the repo
+# so that we can cache the docker layer for the poetry install step.
+# If these files change, the later poetry install will handle it.
+RUN curl -fsSL https://raw.githubusercontent.com/${REPO}/main/pyproject.toml -o ${APP_DIR}pyproject.toml && \
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/poetry.lock -o ${APP_DIR}poetry.lock && \
+     poetry install --sync --only main --no-root --no-interaction && \
     poetry cache clear -n --all pypi && \
     rm -Rf /root/.cache && \
     find /opt /usr -type d -name "__pycache__" -exec rm -rf {} +
 
-# Install code
+# Do final poetry install, when the layers are cached, this is the only step that will run
 COPY . $APP_DIR
+RUN POETRY_VIRTUALENVS_CREATE=false poetry install --sync --only main --no-interaction && \
+    poetry cache clear -n --all pypi && \
+    rm -Rf /root/.cache && \
+    find /opt /usr -type d -name "__pycache__" -exec rm -rf {} +
 
 EXPOSE 8000
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1413,6 +1413,22 @@ botocore = ">=1.12.36,<2.0a.0"
 crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
+name = "setuptools"
+version = "69.1.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1609,4 +1625,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "486b212d14b5e7f1468cff9d20263ab216aced36927e9b497b039e2f83f8166d"
+content-hash = "983d6be4bff66449d06016e479e0e3a62d1a55e93c0dc927ff41c9fc9f3eebe2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ python-stdnum = "1.19"
 pytz = "^2023.2"
 pyuwsgi = ">=2.0,<2.1"
 requests = "^2.31"
+setuptools = "^69.1.0"
 
 [tool.poetry.group.ci.dependencies]
 dunamai = "^1.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ description = "Virtual Library Card Creator"
 homepage = "https://thepalaceproject.org"
 license = "Apache-2.0"
 name = "Virtual Library Card"
+packages = [
+    {include = "virtual_library_card"},
+    {include = "virtuallibrarycard"},
+]
 readme = "README.md"
 repository = "https://github.com/ThePalaceProject/virtual-library-card"
 version = "0"  # Version number is managed with tags in git


### PR DESCRIPTION
## Description

The docker build was failing the install the vlc package with poetry with the following error:
```
#9 8.278 Installing the current project: Virtual Library Card (0)
#9 8.279
#9 8.279 The current project could not be installed: [Errno 2] No such file or directory: '/virtual_library_card/README.md'
#9 8.279 If you do not want to install the current project use --no-root
```

This does some work on caching, and resolves that error in the docker builds.
