### PR TITLE
Fix docker compose up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ARG REPO=ThePalaceProject/virtual-library-card
 
 # Install system
 RUN apt-get update -y && \
+    apt-get install -y libexpat1 && \
     apt-get install --no-install-recommends -y \
     curl mime-support && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version "$POETRY_VERSION" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,8 @@ ARG REPO=ThePalaceProject/virtual-library-card
 
 # Install system
 RUN apt-get update -y && \
-    apt-get install -y libexpat1 && \
     apt-get install --no-install-recommends -y \
-    curl mime-support && \
+    curl mime-support libexpat1 && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version "$POETRY_VERSION" && \
     ln -s /opt/poetry/bin/poetry /bin/poetry && \
     apt-get autoremove -y && \


### PR DESCRIPTION
## Description
This update gets the `docker compose up` command working again. 

Before this change I was seeing the following error:
```
vlc-1    | virtuallibrarycard.Library.customization: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
vlc-1    | 	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
vlc-1    | Superuser created.
vlc-1    | Traceback (most recent call last):
vlc-1    |   File "/usr/local/bin/uwsgi", line 5, in <module>
vlc-1    |     from pyuwsgi import run
vlc-1    | ImportError: libexpat.so.1: cannot open shared object file: No such file or directory
vlc-1 exited with code 1
```
After we we are able to use docker compose up.
<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
