### PR TITLE
[PP-1775] Ensure ssl connections to postgres work when ssl required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.10-slim
 
 ENV APP_DIR=/virtual_library_card/ \
     DJANGO_SETTINGS_MODULE=virtual_library_card.settings.prod \
@@ -25,7 +25,7 @@ ENV UWSGI_MASTER=1 \
 # required for postgres ssl: the crt file doesn't exist
 # but the path must point to a visible directory otherwise we
 # get a permissions error
-ENV PGSSLCERT /tmp/postgresql.crt
+ENV PGSSLCERT=/tmp/postgresql.crt
 
 ARG POETRY_VERSION=1.7.1
 ARG REPO=ThePalaceProject/virtual-library-card

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 ENV APP_DIR=/virtual_library_card/ \
     DJANGO_SETTINGS_MODULE=virtual_library_card.settings.prod \
@@ -21,6 +21,11 @@ ENV UWSGI_MASTER=1 \
     UWSGI_VACUUM=true \
     UWSGI_POST_BUFFERING=1 \
     UWSGI_LOGFORMAT="[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(clean_uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))"
+
+# required for postgres ssl: the crt file doesn't exist
+# but the path must point to a visible directory otherwise we
+# get a permissions error
+ENV PGSSLCERT /tmp/postgresql.crt
 
 ARG POETRY_VERSION=1.7.1
 ARG REPO=ThePalaceProject/virtual-library-card

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Eventually you will be able to pull the container from dockerhub.
 
 Either create a new database in the production PostgreSQL Database. Or use the docker PostgreSQL container for testing.
 
-    docker run -d --name pg --rm -e POSTGRES_USER=vlc -e POSTGRES_PASSWORD=test -e POSTGRES_DB=virtual_library_card postgres:12
+    docker run -d --name pg --rm -e POSTGRES_USER=vlc -e POSTGRES_PASSWORD=test -e POSTGRES_DB=virtual_library_card postgres:16
 
 ### 3. Create settings file
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   # example docker compose configuration for testing and development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,15 @@ services:
       SUPERUSER_PASSWORD: "test"
 
   pg:
-    image: "postgres:12"
+    image: "postgres:16"
     environment:
       POSTGRES_USER: vlc
       POSTGRES_PASSWORD: test
       POSTGRES_DB: virtual_library_card_dev
+    command: >
+             -c ssl=on
+             -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+             -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   minio:
     image: "bitnami/minio:2023.2.27"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       POSTGRES_USER: vlc
       POSTGRES_PASSWORD: test
       POSTGRES_DB: virtual_library_card_dev
+      # AWS RDS requires SSL, so we enable SSL for the database with a self-signed snakeoil cert
+      # so that this database mimics the production databases as closely as we can.
     command: >
              -c ssl=on
              -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ docker =
     docker: minio-vlc
 setenv =
     COVERAGE_FILE = .coverage.{envname}
+    PG_SSL_MODE = allow
+
 allowlist_externals =
     poetry
 
@@ -27,11 +29,12 @@ allowlist_externals =
     coverage
 
 [docker:db-vlc]
-image = postgres:12
+image = postgres:16
 environment =
     POSTGRES_USER=vlc
     POSTGRES_PASSWORD=test
     POSTGRES_DB=test_virtual_library_card_dev
+
 expose =
     VLC_DEV_DB_PORT=5432/tcp
 host_var =

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ docker =
     docker: minio-vlc
 setenv =
     COVERAGE_FILE = .coverage.{envname}
-    PG_SSL_MODE = allow
-
+    VLC_DEV_DB_SSL_MODE = allow
 allowlist_externals =
     poetry
 
@@ -34,7 +33,6 @@ environment =
     POSTGRES_USER=vlc
     POSTGRES_PASSWORD=test
     POSTGRES_DB=test_virtual_library_card_dev
-
 expose =
     VLC_DEV_DB_PORT=5432/tcp
 host_var =

--- a/virtual_library_card/settings/dev.py
+++ b/virtual_library_card/settings/dev.py
@@ -22,6 +22,7 @@ DATABASES = {
         "PASSWORD": "test",
         "HOST": os.environ.get("VLC_DEV_DB_HOST", "pg"),
         "PORT": os.environ.get("VLC_DEV_DB_PORT", "5432"),
+        "OPTIONS": {"sslmode": "require"},
     }
 }
 

--- a/virtual_library_card/settings/dev.py
+++ b/virtual_library_card/settings/dev.py
@@ -22,7 +22,7 @@ DATABASES = {
         "PASSWORD": "test",
         "HOST": os.environ.get("VLC_DEV_DB_HOST", "pg"),
         "PORT": os.environ.get("VLC_DEV_DB_PORT", "5432"),
-        "OPTIONS": {"sslmode": os.environ.get("PG_SSL_MODE", "require")},
+        "OPTIONS": {"sslmode": os.environ.get("VLC_DEV_DB_SSL_MODE", "require")},
     }
 }
 

--- a/virtual_library_card/settings/dev.py
+++ b/virtual_library_card/settings/dev.py
@@ -22,7 +22,7 @@ DATABASES = {
         "PASSWORD": "test",
         "HOST": os.environ.get("VLC_DEV_DB_HOST", "pg"),
         "PORT": os.environ.get("VLC_DEV_DB_PORT", "5432"),
-        "OPTIONS": {"sslmode": "require"},
+        "OPTIONS": {"sslmode": os.environ.get("PG_SSL_MODE", "require")},
     }
 }
 


### PR DESCRIPTION
## Description

When we upgraded to Postgres 16 in the tpp-dev environment, VLC was failing because PG 16 requires SSL connections by default.   

This update fixes the problem in the docker container.  In order to verify SSL connections are happening I enabled SSL for postgres 16 in the docker compose script and for extra certainty that the client is using SSL I updated the dev settings to specify the pg ssl mode.  

THIS PR should be merged after https://github.com/ThePalaceProject/virtual-library-card/pull/285 is merged.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1775

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Manually tested using `docker compose up`.   Without the update to the docker image I was getting the same error we were seeing in tpp-dev.  With it I, I am able to connect.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
