### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This prevents duplicated runs on internal PRs.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-![Python: 3.10,3.11](https://img.shields.io/badge/Python-3.10%20|%203.11-blue)
+![Python: 3.10,3.11,3.12](https://img.shields.io/badge/Python-3.10%20|%203.11%20|%203.12-blue)
 
 ## Prerequisites
 
@@ -229,6 +229,7 @@ flag.
 |-------------|----------------|
 | py310       | Python 3.10    |
 | py311       | Python 3.11    |
+| py312       | Python 3.12    |
 
 All of these environments are tested by default when running tox. To test one specific environment you can use the `-e`
 flag.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-docker
+envlist = py{310,311,312}-docker
 skipsdist = true
 
 [testenv]
@@ -54,7 +54,6 @@ host_var =
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312


### PR DESCRIPTION
## Description

Run tests against Python 3.12 and remove a couple old references to Python 3.8 and 3.9.

## Motivation and Context

Make sure we are compatible for upgrade when the time comes 🚀 

Similar to: https://github.com/ThePalaceProject/circulation/pull/2146

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
