### PR TITLE
Exclude confusing characters from barcodes (PP-1644)

### DIFF
--- a/tests/misc/test_card_number.py
+++ b/tests/misc/test_card_number.py
@@ -9,10 +9,18 @@ from virtuallibrarycard.models import LibraryCard
 
 
 class TestCardNumber(BaseUnitTest):
-    def test_allowed_characters(self):
-        assert len(CardNumber.ALLOWED_CHARACTERS) == 36
-        assert CardNumber.ALLOWED_CHARACTERS[0] == "0"
-        assert CardNumber.ALLOWED_CHARACTERS[-1] == "Z"
+    def test__generate_random_characters(self):
+        # Test the generation of random characters
+        random_chars = CardNumber._generate_random_characters(10)
+        assert len(random_chars) == 10
+        assert all(c in CardNumber.ALLOWED_CHARACTERS for c in random_chars)
+        assert all(c not in random_chars for c in "01liLIOo")
+
+        # Test the generation of random characters with a different length
+        random_chars = CardNumber._generate_random_characters(5)
+        assert len(random_chars) == 5
+        assert all(c in CardNumber.ALLOWED_CHARACTERS for c in random_chars)
+        assert all(c not in random_chars for c in "01liLIOo")
 
     def test_generate_card_number(self):
         lc = LibraryCard(library=self._default_library)

--- a/virtual_library_card/card_number.py
+++ b/virtual_library_card/card_number.py
@@ -13,10 +13,8 @@ class CardNumber:
     CARD_NUMBER_LENGTH = 14
     # Minimum length the random part should be
     MIN_RANDOM_LENGTH = 4
-    # What characters are allowed in the random sequence, 0-9 A-Z
-    ALLOWED_CHARACTERS = [str(i) for i in range(10)] + [
-        chr(i) for i in range(ord("A"), ord("Z") + 1)
-    ]
+    # What characters are allowed in the random sequence, removes some confusing characters
+    ALLOWED_CHARACTERS = "23456789ABCDEFGHJKMNPRSTUVWXYZabcdefghjkmnpqrstuvwxyz"
 
     @classmethod
     def _generate_random_characters(cls, length: int):


### PR DESCRIPTION
## Description

Only generate barcodes with characters in this set: `23456789ABCDEFGHJKMNPRSTUVWXYZabcdefghjkmnpqrstuvwxyz`

## Motivation and Context

We use both letters and numbers when generating VLC barcodes, but some letters resemble numbers which can be confusing for users. We should not use such letters when generating a barcode (though they should still be allowed as a prefix): O/o, I/i, L/l.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
