### PR TITLE
Bump poetry version to match dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Poetry
         uses: ThePalaceProject/circulation/.github/actions/poetry@main
         with:
-          version: "1.7.1"
+          version: "2.1.1"
 
       - name: Setup Dunamai
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry
         uses: ThePalaceProject/circulation/.github/actions/poetry@main
         with:
-          version: "1.7.1"
+          version: "2.1.1"
 
       - name: Install Pre-commit
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Poetry
         uses: ThePalaceProject/circulation/.github/actions/poetry@main
         with:
-          version: "1.7.1"
+          version: "2.1.1"
 
       - name: Install Tox
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,14 +49,14 @@ WORKDIR $APP_DIR
 # If these files change, the later poetry install will handle it.
 RUN curl -fsSL https://raw.githubusercontent.com/${REPO}/main/pyproject.toml -o ${APP_DIR}pyproject.toml && \
     curl -fsSL https://raw.githubusercontent.com/${REPO}/main/poetry.lock -o ${APP_DIR}poetry.lock && \
-     poetry install --sync --only main --no-root --no-interaction && \
+    poetry sync --only main --no-root --no-interaction && \
     poetry cache clear -n --all pypi && \
     rm -Rf /root/.cache && \
     find /opt /usr -type d -name "__pycache__" -exec rm -rf {} +
 
 # Do final poetry install, when the layers are cached, this is the only step that will run
 COPY . $APP_DIR
-RUN POETRY_VIRTUALENVS_CREATE=false poetry install --sync --only main --no-interaction && \
+RUN POETRY_VIRTUALENVS_CREATE=false poetry sync --only main --no-interaction && \
     poetry cache clear -n --all pypi && \
     rm -Rf /root/.cache && \
     find /opt /usr -type d -name "__pycache__" -exec rm -rf {} +

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV UWSGI_MASTER=1 \
 # get a permissions error
 ENV PGSSLCERT=/tmp/postgresql.crt
 
-ARG POETRY_VERSION=1.7.1
+ARG POETRY_VERSION=2.1.1
 ARG REPO=ThePalaceProject/virtual-library-card
 
 # Install system


### PR DESCRIPTION
## Description

Bump up the Poetry version we are using to match what dependabot uses.

Similar PR to bump CM version: https://github.com/ThePalaceProject/circulation/pull/2403

## Motivation and Context

I've noticed some messages in our CI lately that the lock file version may not be supported, since dependabot has moved to a 2.x version of Poetry.

## How Has This Been Tested?

- Build in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
