### PR TITLE
Update our pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -17,14 +17,14 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args:
           - --py310-plus
 
   - repo: https://github.com/myint/autoflake
-    rev: v2.2.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args:
@@ -33,32 +33,32 @@ repos:
           - --ignore-init-module-imports
 
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 25.1.0
     hooks:
       - id: black
         name: Run black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: Run isort
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.28.0
+    rev: 0.33.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
 
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
+    rev: v0.24.2
     hooks:
       - id: toml-sort
         args: []
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.17
+    rev: v0.9.29
     hooks:
       - id: pymarkdown
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ source = ["virtual_library_card", "virtuallibrarycard"]
 django_settings_module = "virtual_library_card.settings.dev"
 
 [tool.isort]
+combine_as_imports = true
 profile = "black"
 
 [tool.mypy]

--- a/virtuallibrarycard/business_rules/library_card.py
+++ b/virtuallibrarycard/business_rules/library_card.py
@@ -257,7 +257,7 @@ class LibraryCardBulkUpload:
         return True
 
 
-def iter_clean_lines(io: IO) -> Generator[str, None, None]:
+def iter_clean_lines(io: IO) -> Generator[str]:
     """Iterate over an IO object and ignore blank lines
     This is to specifically ignore empty last lines in csvs
     decoding is done through charset detection


### PR DESCRIPTION
## Description

Updates our pre-commit linters. Figured I would do this while updating poetry.

## Motivation and Context

This PR was created by running:
```
pre-commit autoupdate
pre-commit run -a
```

So all the changes are automated from our linters.  I also added the `combine_as_imports` isort option to match the changes to CM.

Similar to: https://github.com/ThePalaceProject/circulation/pull/2411

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
