### PR TITLE
Fix privacy URL references 

### DIFF
--- a/tests/misc/test_user_session.py
+++ b/tests/misc/test_user_session.py
@@ -25,7 +25,7 @@ class TestUserSessionManager(BaseUnitTest):
         assert request.session["email"] == library.email
         assert request.session["places"] == ["NY"]
         assert request.session["terms_conditions_url"] == library.terms_conditions_url
-        assert request.session["privacy_url"] == library.terms_conditions_url
+        assert request.session["privacy_url"] == library.privacy_url
 
     def test_clean_session_data(self):
         request = mock.MagicMock()
@@ -42,6 +42,7 @@ class TestUserSessionManager(BaseUnitTest):
                 mock.call("email", None),
                 mock.call("places", None),
                 mock.call("terms_conditions_url", None),
+                mock.call("privacy_url", None),
             ]
         )
 

--- a/virtual_library_card/user_session.py
+++ b/virtual_library_card/user_session.py
@@ -43,7 +43,7 @@ class UserSessionManager:
         request.session["email"] = library.email
         request.session["places"] = library.get_places()
         request.session["terms_conditions_url"] = library.terms_conditions_url
-        request.session["privacy_url"] = library.terms_conditions_url
+        request.session["privacy_url"] = library.privacy_url
 
     @staticmethod
     def clean_session_data(request):
@@ -57,6 +57,7 @@ class UserSessionManager:
         request.session.pop("email", None)
         request.session.pop("places", None)
         request.session.pop("terms_conditions_url", None)
+        request.session.pop("privacy_url", None)
 
     @staticmethod
     def set_context_library_cards(context, user):


### PR DESCRIPTION
## Description

- Update `session["privacy_url"]` to library.privacy_url
- Make sure `session["privacy_url"]` is cleaned up

## Motivation and Context

I noticed while working on https://github.com/ThePalaceProject/virtual-library-card/pull/465 that we are storing the libraries `terms_conditions_url` in the session as `privacy_url`.

I'm not sure this is every actually used, so we might just be able to pull these all out of the session, but I wanted to at least fix it so it contains what it says it contains while I noticed it.

## How Has This Been Tested?

- Running unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
