### PR TITLE
Fix logout 405 error for non-staff/non-superuser accounts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -424,6 +424,44 @@ h1, h2, h3, h4, h5, h6, figure {
     box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
 }
 
+.main-nav ul li.btn-main-nav form {
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+
+.main-nav ul li.btn-main-nav button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    padding: 30px 0px !important;
+    color: var(--header-nav-btn-color);
+}
+
+.main-nav ul li.btn-main-nav button span {
+    background: var(--header-nav-btn-bg);
+    padding: 4px 10px;
+    display: -moz-inline-stack;
+    display: inline-block;
+    zoom: 1;
+    *display: inline;
+    -webkit-transition: 0.3s;
+    -o-transition: 0.3s;
+    transition: 0.3s;
+    -webkit-border-radius: 1px;
+    -moz-border-radius: 1px;
+    -ms-border-radius: 1px;
+    border-radius: 1px;
+    color: var(--header-nav-btn-color);
+}
+
+.main-nav ul li.btn-main-nav button:hover span {
+    -webkit-box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
+    -moz-box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
+    box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
+}
+
 .main-nav ul li.active > a {
     font-weight: 400;
 }
@@ -1302,7 +1340,8 @@ form .help-block {
     border: solid 4px rgba(0, 0, 0, 0.3);
 }
 
-.main-nav ul li.btn-main-nav a:focus span {
+.main-nav ul li.btn-main-nav a:focus span,
+.main-nav ul li.btn-main-nav button:focus span {
     background-color: var(--header-link-color);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -395,34 +395,6 @@ h1, h2, h3, h4, h5, h6, figure {
     color: var(--header-color);
 }
 
-.main-nav ul li.btn-main-nav a {
-    padding: 30px 0px !important;
-    color: var(--header-nav-btn-color);
-}
-
-
-.main-nav ul li.btn-main-nav a span {
-    background: var(--header-nav-btn-bg);
-    padding: 4px 10px;
-    display: -moz-inline-stack;
-    display: inline-block;
-    zoom: 1;
-    *display: inline;
-    -webkit-transition: 0.3s;
-    -o-transition: 0.3s;
-    transition: 0.3s;
-    -webkit-border-radius: 1px;
-    -moz-border-radius: 1px;
-    -ms-border-radius: 1px;
-    border-radius: 1px;
-    color: var(--header-nav-btn-color);
-}
-
-.main-nav ul li.btn-main-nav a:hover span {
-    -webkit-box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
-    -moz-box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
-    box-shadow: 0px 14px 20px -9px rgba(0, 0, 0, 0.75);
-}
 
 .main-nav ul li.btn-main-nav form {
     display: inline;
@@ -1340,7 +1312,6 @@ form .help-block {
     border: solid 4px rgba(0, 0, 0, 0.3);
 }
 
-.main-nav ul li.btn-main-nav a:focus span,
 .main-nav ul li.btn-main-nav button:focus span {
     background-color: var(--header-link-color);
 }

--- a/templates/django/includes/menu.html
+++ b/templates/django/includes/menu.html
@@ -90,8 +90,12 @@
                             </li>
                         {% endif %}
                         {% if user.is_authenticated %}
-                            <li class="btn-main-nav"><a title="{% trans logout %}" aria-label="{% trans logout %}"
-                                                        href="{% url 'logout' %}?next=/accounts/login?next=/"><span>{% trans logout %}</span></a>
+                            <li class="btn-main-nav">
+                                <form method="post" action="{% url 'logout' %}">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="next" value="/accounts/login?next=/">
+                                    <button type="submit" title="{% trans logout %}" aria-label="{% trans logout %}"><span>{% trans logout %}</span></button>
+                                </form>
                             </li>
                         {% endif %}
 

--- a/tests/views/test_profile_views.py
+++ b/tests/views/test_profile_views.py
@@ -217,9 +217,7 @@ class TestLogoutView(BaseUnitTest):
         self.client.force_login(user)
         assert "_auth_user_id" in self.client.session
 
-        response = self.client.post(
-            self.LOGOUT_URL, {"next": "/accounts/login?next=/"}
-        )
+        response = self.client.post(self.LOGOUT_URL, {"next": "/accounts/login?next=/"})
         assert response.status_code == 302
         assert "_auth_user_id" not in self.client.session
 

--- a/tests/views/test_profile_views.py
+++ b/tests/views/test_profile_views.py
@@ -1,4 +1,5 @@
 from django.test import RequestFactory
+from django.urls import reverse
 from pytest_django.asserts import assertFormError
 
 from tests.base import BaseUnitTest
@@ -207,3 +208,31 @@ class TestCustomLoginView(BaseUnitTest):
                 "Please enter a correct Email address and password. Note that both fields may be case-sensitive."
             ],
         )
+
+
+class TestLogoutView(BaseUnitTest):
+    LOGOUT_URL = reverse("logout")
+
+    def _assert_login_and_logout(self, user):
+        self.client.force_login(user)
+        assert "_auth_user_id" in self.client.session
+
+        response = self.client.post(
+            self.LOGOUT_URL, {"next": "/accounts/login?next=/"}
+        )
+        assert response.status_code == 302
+        assert "_auth_user_id" not in self.client.session
+
+    def test_logout_ordinary_user(self):
+        user = self.create_user(self._default_library)
+        self._assert_login_and_logout(user)
+
+    def test_logout_staff_user(self):
+        user = self.create_user(self._default_library, is_staff=True)
+        self._assert_login_and_logout(user)
+
+    def test_logout_superuser(self):
+        user = CustomUser.objects.create_superuser(
+            f"{self._random_name()}@example.com", "password"
+        )
+        self._assert_login_and_logout(user)


### PR DESCRIPTION
## Summary
- Replaces the logout `<a>` link (GET request) with a `<form method="post">` that includes a CSRF token (mirroring superadmin view logout)
- Django 5.0+ requires POST for `LogoutView`; GET requests return 405 Method Not Allowed
- Passes the `next` redirect value as a hidden input, preserving the original redirect behavior

## Test plan
- [x] Log in as a regular (non-staff, non-superuser) account and verify the logout button works
- [x] Log in as a staff/superuser account and verify the logout button still works
- [x] Verify redirect lands on `/accounts/login?next=/` after logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)