### PR TITLE
Use central github-actions repo for jira-release-sync

### DIFF
--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Sync release to Jira
-        uses: ThePalaceProject/circulation/.github/actions/jira-release-sync@main
+        uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:
           jira-base-url: ${{ secrets.JIRA_BASE_URL }}
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -6,9 +6,6 @@ jobs:
   sync-to-jira:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Sync release to Jira
         uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:


### PR DESCRIPTION
## Description

Update the `jira-release-sync` workflow to consume the action from the central `ThePalaceProject/github-actions` repository at the `v1` tag, instead of pulling it from `ThePalaceProject/circulation@main`.

## Motivation and Context

The `jira-release-sync` action has been moved to a central `github-actions` repo so it can be versioned and shared across projects. Pinning to the `v1` tag also avoids tracking a moving `main` branch.

## How Has This Been Tested?

No functional change to the workflow inputs — will be exercised on the next release publish event.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.